### PR TITLE
fix: encode ThreatDown Nebula scan IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) ThreatDown, 2019-2025
+   Copyright (c) ThreatDown, 2019-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: ThreatDown Nebula
-Copyright (c) ThreatDown, 2019-2025
+Copyright (c) ThreatDown, 2019-2026
 Third Party Software Attributions:
 
 @@@@============================================================================
@@ -60,4 +60,3 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ThreatDown Nebula
 
-Publisher: ThreatDown \
-Connector Version: 2.3.0 \
-Product Vendor: ThreatDown \
-Product Name: Malwarebytes Endpoint Protection \
+Publisher: ThreatDown <br>
+Connector Version: 2.3.0 <br>
+Product Vendor: ThreatDown <br>
+Product Name: Malwarebytes Endpoint Protection <br>
 Minimum Product Version: 6.2.2
 
 This app integrates with the ThreatDown (powered by Malwarebytes) Nebula platform to perform prevention, detection, remediation, and forensics endpoint management tasks
@@ -27,23 +27,23 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[scan and remediate](#action-scan-and-remediate) - Scan an endpoint and remediate threats found \
-[scan and report](#action-scan-and-report) - Scan an endpoint and report threats found \
-[isolate endpoint](#action-isolate-endpoint) - When threats are found, isolate a network, process, or desktop endpoint \
-[isolate process](#action-isolate-process) - When threats are found, isolate a process endpoint \
-[isolate network](#action-isolate-network) - Network Isolation on an endpoint when threats are found \
-[isolate desktop](#action-isolate-desktop) - Desktop Isolation an endpoint when threats are found \
-[deisolate endpoint](#action-deisolate-endpoint) - Deisolate endpoint after threats are removed \
-[list endpoints](#action-list-endpoints) - List all the endpoints/sensors configured on the device \
-[get endpoint info](#action-get-endpoint-info) - Get information about an endpoint \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[scan and remediate](#action-scan-and-remediate) - Scan an endpoint and remediate threats found <br>
+[scan and report](#action-scan-and-report) - Scan an endpoint and report threats found <br>
+[isolate endpoint](#action-isolate-endpoint) - When threats are found, isolate a network, process, or desktop endpoint <br>
+[isolate process](#action-isolate-process) - When threats are found, isolate a process endpoint <br>
+[isolate network](#action-isolate-network) - Network Isolation on an endpoint when threats are found <br>
+[isolate desktop](#action-isolate-desktop) - Desktop Isolation an endpoint when threats are found <br>
+[deisolate endpoint](#action-deisolate-endpoint) - Deisolate endpoint after threats are removed <br>
+[list endpoints](#action-list-endpoints) - List all the endpoints/sensors configured on the device <br>
+[get endpoint info](#action-get-endpoint-info) - Get information about an endpoint <br>
 [get scan info](#action-get-scan-info) - Get information about a scan job
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -58,7 +58,7 @@ No Output
 
 Scan an endpoint and remediate threats found
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -83,7 +83,7 @@ summary.total_objects_successful | numeric | | |
 
 Scan an endpoint and report threats found
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -108,7 +108,7 @@ summary.total_objects_successful | numeric | | |
 
 When threats are found, isolate a network, process, or desktop endpoint
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -133,7 +133,7 @@ summary.total_objects_successful | numeric | | |
 
 When threats are found, isolate a process endpoint
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -158,7 +158,7 @@ summary.total_objects_successful | numeric | | |
 
 Network Isolation on an endpoint when threats are found
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -183,7 +183,7 @@ summary.total_objects_successful | numeric | | |
 
 Desktop Isolation an endpoint when threats are found
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -208,7 +208,7 @@ summary.total_objects_successful | numeric | | |
 
 Deisolate endpoint after threats are removed
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -233,7 +233,7 @@ summary.total_objects_successful | numeric | | |
 
 List all the endpoints/sensors configured on the device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -263,7 +263,7 @@ summary.total_objects_successful | numeric | | 0 |
 
 Get information about an endpoint
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -295,7 +295,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get information about a scan job
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -334,7 +334,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) ThreatDown, 2019-2025
+# Copyright (c) ThreatDown, 2019-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Encodes scan IDs before using them in ThreatDown Nebula API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Encodes scan IDs before using them in ThreatDown Nebula API paths.
+* Encodes scan IDs before using them in ThreatDown Nebula API paths.

--- a/threatdownnebula.json
+++ b/threatdownnebula.json
@@ -10,7 +10,7 @@
     "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "ThreatDown",
-    "license": "Copyright (c) ThreatDown, 2019-2025",
+    "license": "Copyright (c) ThreatDown, 2019-2026",
     "app_version": "2.3.0",
     "utctime_updated": "2026-03-02T07:12:10.594682Z",
     "package_name": "phantom_threatdownnebula",
@@ -964,6 +964,18 @@
         }
     ],
     "pip39_dependencies": {
+        "wheel": [
+            {
+                "module": "oauthlib",
+                "input_file": "wheels/shared/oauthlib-3.1.0-py2.py3-none-any.whl"
+            },
+            {
+                "module": "requests_oauthlib",
+                "input_file": "wheels/shared/requests_oauthlib-1.3.1-py2.py3-none-any.whl"
+            }
+        ]
+    },
+    "pip313_dependencies": {
         "wheel": [
             {
                 "module": "oauthlib",

--- a/threatdownnebula_connector.py
+++ b/threatdownnebula_connector.py
@@ -1,6 +1,6 @@
 # File: threatdownnebula_connector.py
 #
-# Copyright (c) ThreatDown, 2019-2025
+# Copyright (c) ThreatDown, 2019-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/threatdownnebula_connector.py
+++ b/threatdownnebula_connector.py
@@ -20,6 +20,7 @@
 import json
 import time
 from datetime import datetime
+from urllib.parse import quote
 
 import phantom.app as phantom
 import requests
@@ -437,7 +438,7 @@ class ThreatDownNebulaConnector(BaseConnector):
             ret_val, nebula = self._get_nebula_client(action_result)
             if phantom.is_fail(ret_val):
                 return action_result.get_status()
-            response = nebula.get(self.NEBULA_URL("/api/v2/scans/" + scan_id))
+            response = nebula.get(self.NEBULA_URL("/api/v2/scans/" + quote(str(scan_id), safe="")))
             data = json.loads(response.text)
             self.save_progress(f"response: {response.text}")
         except Exception as err:


### PR DESCRIPTION
## Summary

- URL-encode `get scan info` scan IDs as a single API path segment.
- Refresh the connector validation-tooling baseline before the functional fix.

## Tracking

- PAPP-38080 under ESPM-5228
- PSAAS-31365
- VULN-94090
- FS-2243

## Validation

- `pre-commit run --all-files --show-diff-on-failure` (Python 3.13, public PyPI): passed
- `git diff --check`: passed

Written by Codex.